### PR TITLE
fix compile error

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -1285,7 +1285,7 @@ _gpgrt_logv_printhex (const void *buffer, size_t length,
             {
               if (trunc)
                 {
-                  _gpgrt_log_printf (" …");
+                  _gpgrt_log_printf (" ...");
                   break;
                 }
 


### PR DESCRIPTION
```
1>FFVS\source\libgpg-error\src\logging.c(1288,38): error C2001: newline in constant
```
fix compile error